### PR TITLE
Use forked scalyr null-label module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source      = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  source      = "git::https://github.com/scalyr/terraform-null-label.git?ref=tags/0.16.0-scalyr"
   namespace   = var.namespace
   stage       = var.stage
   environment = var.environment


### PR DESCRIPTION
Use the forked scalyr null-label module. After this is merged the resulting commit should be tagged as 0.22.0-1-scalyr.